### PR TITLE
Removed old password field when changing self password from users

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/users/change-password.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/users/change-password.html
@@ -22,17 +22,6 @@
                     <span class="help-inline" val-msg-for="resetPassword" val-toggle-msg="valServerField"></span>
                 </umb-control-group>
 
-                <!-- we need to show the old pass field when the provider cannot retrieve the password -->
-                <umb-control-group alias="oldPassword" label="@user_oldPassword" ng-if="$parent.showOldPass()" required="true">
-                    <input type="password" name="oldPassword" ng-model="$parent.passwordValues.oldPassword"
-                           class="input-block-level umb-textstring textstring"
-                           required
-                           val-server-field="oldPassword" 
-                           no-dirty-check />
-                    <span class="help-inline" val-msg-for="oldPassword" val-toggle-msg="required">Required</span>
-                    <span class="help-inline" val-msg-for="oldPassword" val-toggle-msg="valServerField"></span>
-                </umb-control-group>
-
                 <umb-control-group alias="password" label="@user_newPassword" ng-if="!$parent.showReset" required="true">
                     <input type="password" name="password" ng-model="$parent.passwordValues.newPassword"
                            class="input-block-level umb-textstring textstring"


### PR DESCRIPTION

### Prerequisites

- [x] I have [created an issue](https://github.com/umbraco/Umbraco-CMS/issues) for the proposed changes in this PR, the link is: https://github.com/umbraco/Umbraco-CMS/issues/3069

- [x] I have added steps to test this contribution in the description below 
When changing the password of your own user in the users section, the old password field shouldn't show up.

### Description
<!-- A description of the changes proposed in the pull-request --> Removed old password field when changing the password of your own user in the users section. It is however not used in any validation so it should simply be removed from the UI like it is in the other 'change password' functionality.

<!-- Make sure to link to the related issue number so we can easily find it in the issue tracker -->
https://github.com/umbraco/Umbraco-CMS/issues/3069


<!-- Thanks for contributing to Umbraco CMS! -->
